### PR TITLE
chore: Use uv source for Singer SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,6 @@ module = [
 [tool.uv]
 prerelease = "allow"
 required-version = ">=0.5.19"
+
+[tool.uv.sources]
+singer-sdk = { git = "https://github.com/meltano/sdk.git", rev = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -782,8 +782,8 @@ wheels = [
 
 [[package]]
 name = "singer-sdk"
-version = "0.48.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.48.1.dev14+ge45962633"
+source = { git = "https://github.com/meltano/sdk.git?rev=main#e45962633838fdb9d627309879c6287fd7a32689" }
 dependencies = [
     { name = "backoff" },
     { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'" },
@@ -804,10 +804,6 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "universal-pathlib" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/98/05cb9ec8361b05e67f6dc7f53f65b9c1e6a9f410bead94ad49e7ea2a6b18/singer_sdk-0.48.0.tar.gz", hash = "sha256:8b82948ed9eac7ab5ebca6728b010fb3e003a2570c9628c66d5b677f0c8648b6", size = 1302031, upload-time = "2025-08-04T20:30:55.19Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/91/62937f6d9c52d2cb6333b414963a4d3fd07b15e3ea223cdce952e46db4d8/singer_sdk-0.48.0-py3-none-any.whl", hash = "sha256:8c482a92b5205a8ec5ecde5701948fc49fd0d47737b26d16c18253ffeb7d26aa", size = 193246, upload-time = "2025-08-04T20:30:53.441Z" },
 ]
 
 [package.optional-dependencies]
@@ -890,7 +886,7 @@ typing = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "singer-sdk", specifier = "~=0.48.0" }]
+requires-dist = [{ name = "singer-sdk", git = "https://github.com/meltano/sdk.git?rev=main" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -899,7 +895,7 @@ dev = [
     { name = "pytest", specifier = ">=7.4" },
     { name = "pytest-durations" },
     { name = "pytest-github-actions-annotate-failures" },
-    { name = "singer-sdk", extras = ["testing"] },
+    { name = "singer-sdk", extras = ["testing"], git = "https://github.com/meltano/sdk.git?rev=main" },
     { name = "types-requests" },
 ]
 testing = [
@@ -907,7 +903,7 @@ testing = [
     { name = "pytest", specifier = ">=7.4" },
     { name = "pytest-durations" },
     { name = "pytest-github-actions-annotate-failures" },
-    { name = "singer-sdk", extras = ["testing"] },
+    { name = "singer-sdk", extras = ["testing"], git = "https://github.com/meltano/sdk.git?rev=main" },
 ]
 typing = [
     { name = "mypy" },


### PR DESCRIPTION
- **chore(deps): lock file maintenance (#390)**
- **chore(deps): update dependency tox-uv to v1.26.2 (#391)**
- **chore(deps): update pre-commit hook astral-sh/ruff-pre-commit to v0.12.8 (#392)**
- **chore(deps): update svenstaro/upload-release-action action to v2.9.1 (#393)**
- **chore(deps): update uv-version (patch) (#394)**
- **chore(deps): update astral-sh/setup-uv action to v6.3.1 (#396)**
- **chore(deps): update astral-sh/setup-uv action to v6.4.3 (#397)**
- **chore(deps): update svenstaro/upload-release-action action to v2.10.0 (#402)**
- **chore(deps): update svenstaro/upload-release-action action to v2.11.2 (#403)**
- **chore: Require Do not use uv source for Singer SDK in `main`**
- **chore: Use uv source for Singer SDK**
